### PR TITLE
fix typo under README License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,3 @@ N/A
 ## License
 
 MIT Lincense
----


### PR DESCRIPTION
This PR fixes a type under the license section of README